### PR TITLE
[Feat/#284] 알림페이지 최적화

### DIFF
--- a/daeng/index.html
+++ b/daeng/index.html
@@ -6,8 +6,8 @@
     <meta http-equiv="Content-Security-Policy" content="upgrade-insecure-requests" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=5" />
     <meta name="description" content="댕댕어디가" />
-    <link loading="lazy" as="image" href="/staticmap.webp" type="image/webp" fetchpriority="high" loading="lazy"/>
-    <link loading="lazy" as="image" href="/hopscotchmap.webp" type="image/webp" fetchpriority="high" loading="lazy"/>
+    <link as="image" href="/staticmap.webp" type="image/webp" fetchpriority="high" loading="lazy"/>
+    <link as="image" href="/hopscotchmap.webp" type="image/webp" fetchpriority="high" loading="lazy"/>
     <title>댕댕어디가</title>
 
     <meta property="og:title" content="댕댕어디가">

--- a/daeng/index.html
+++ b/daeng/index.html
@@ -6,8 +6,8 @@
     <meta http-equiv="Content-Security-Policy" content="upgrade-insecure-requests" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=5" />
     <meta name="description" content="댕댕어디가" />
-    <link rel="preload" as="image" href="/staticmap.webp" type="image/webp" fetchpriority="high" />
-    <link rel="preload" as="image" href="/hopscotchmap.webp" type="image/webp" fetchpriority="high" />
+    <link loading="lazy" as="image" href="/staticmap.webp" type="image/webp" fetchpriority="high" loading="lazy"/>
+    <link loading="lazy" as="image" href="/hopscotchmap.webp" type="image/webp" fetchpriority="high" loading="lazy"/>
     <title>댕댕어디가</title>
 
     <meta property="og:title" content="댕댕어디가">

--- a/daeng/src/pages/alarm/AlarmPage.jsx
+++ b/daeng/src/pages/alarm/AlarmPage.jsx
@@ -1,13 +1,12 @@
 import React, { useEffect, useState } from "react";
 import Header from "../../components/commons/Header";
 import Footer from "../../components/commons/Footer";
-import styled from "styled-components";
+import styled, { keyframes } from "styled-components";
 import { requestNotificationPermission } from "../../firebase/firebaseMessaging";
 import AlertDialog from "../../components/commons/SweetAlert";
 import axiosInstance from "../../services/axiosInstance";
 import { pushAgree } from "../../data/CommonCode";
 import AlarmList from "../../components/alarm/AlarmList";
-import Loading from "../../components/commons/Loading";
 
 const PageContainer = styled.div`
   display: flex;
@@ -48,6 +47,30 @@ const ToggleButton = styled.button`
       isSubscribed ? "#FFD7EB" : "#FF4580"};
   }
 `;
+
+const skeletonAnimation = keyframes`
+  0% { background-color: #e0e0e0; }
+  50% { background-color: #f0f0f0; }
+  100% { background-color: #e0e0e0; }
+`;
+
+const SkeletonBox = styled.div`
+  width: 100%;
+  height: ${({ height }) => height || "20px"};
+  margin: 10px 0;
+  border-radius: 8px;
+  animation: ${skeletonAnimation} 1.5s infinite ease-in-out;
+`;
+
+function AlarmSkeleton() {
+  return (
+    <AlarmContainer>
+      <SkeletonBox height="50px" />
+      <SkeletonBox height="20px" width="80%" />
+    </AlarmContainer>
+  );
+}
+
 
 function AlarmPage() {
   const [isSubscribed, setIsSubscribed] = useState(false);
@@ -165,21 +188,16 @@ function AlarmPage() {
     <PageContainer>
       <Header label="알림" />
       <Content>
-        {isLoading && <Loading label="처리 중입니다..." />}
-        <AlarmContainer>
-          <ToggleButton
-            isSubscribed={isSubscribed}
-            onClick={isSubscribed ? handleCancelNotification : handleNotificationRequest}
-            disabled={isLoading}
-          >
-            {isSubscribed ? "알림 그만 받기" : "알림 받기"}
-          </ToggleButton>
-          <p>
-            {isSubscribed
-              ? "현재 알림이 활성화된 상태입니다."
-              : "현재 알림이 비활성화된 상태입니다."}
-          </p>
-        </AlarmContainer>
+        {isLoading ? (
+          <AlarmSkeleton /> 
+        ) : (
+          <AlarmContainer>
+            <ToggleButton $isSubscribed={isSubscribed} onClick={isSubscribed ? handleCancelNotification : handleNotificationRequest} disabled={isLoading}>
+              {isSubscribed ? "알림 그만 받기" : "알림 받기"}
+            </ToggleButton>
+            <p>{isSubscribed ? "현재 알림이 활성화된 상태입니다." : "현재 알림이 비활성화된 상태입니다."}</p>
+          </AlarmContainer>
+        )}
         {isSubscribed && <AlarmList activeTab="subscribe" />}
       </Content>
       <Footer />


### PR DESCRIPTION
# 📌 Pull Request Template

## 📄 작업한 기능을 선택해주세요
- [ ] Style
- [x] Bug
- [ ] Feat

## 🔨 변경 사항 
- 알림페이지에 loading 컴포넌트 사용 대신 `skeleton ui` 삽입
- preload는 보통 모든 페이지에서 공통적으로 사용할 때 삽입하기 때문에 `index.html`에 있는 `preload`제거해주고 `loading="lazy"`를 삽입해줬습니다..!!
 
## 📸 스크린샷 
- 콘솔에 발생하는 문제 해결(preload)

<img width="500" alt="스크린샷 2025-02-15 오후 5 15 07" src="https://github.com/user-attachments/assets/274af398-ebb0-4e37-8368-474160fae62c" />

- 개선 전

<img width="500" alt="스크린샷 2025-02-15 오후 5 16 43" src="https://github.com/user-attachments/assets/f1377654-cd1a-49dc-8856-94cf3338ebd8" />

- 개선 후 
<img width="500" alt="스크린샷 2025-02-15 오후 5 16 00" src="https://github.com/user-attachments/assets/c9a12450-0145-4a3a-b13d-df157e09bf07" />



## 🔍 참고 사항

- `접근성`은 폰트 색상 때문에 수정이 힘들어서 변경하지 않을 예정입니다